### PR TITLE
feat: use rootDir option for locating tsconfig.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -214,7 +214,7 @@ exports.configure = (options) => {
         });
 
       if (useTypescript) {
-        config.plugin("typescript-plugin").use(TypescriptPlugin);
+        config.plugin("typescript-plugin").use(TypescriptPlugin, [{ rootDir: variantOptions.rootDir }]);
 
         config.resolve.extensions.merge([".tsx", ".ts"]);
       }

--- a/plugins/typescript/index.js
+++ b/plugins/typescript/index.js
@@ -10,7 +10,7 @@ const diagnosticHost = {
 class TypescriptPlugin {
   constructor(options = {}) {
     this.options = {
-      fileName: "tsconfig.json",
+      fileName: `${options.rootDir ?? ""}tsconfig.json`,
       ...options,
     };
   }
@@ -125,7 +125,7 @@ class TypescriptPlugin {
       ts.sys.readFile
     );
 
-    return ts.parseJsonConfigFileContent(config, ts.sys, compiler.context);
+    return ts.parseJsonConfigFileContent(config, ts.sys, this.options.rootDir ?? compiler.context);
   }
 }
 


### PR DESCRIPTION
Since the dashboard, graphics and extension may all have different requirements when it comes to the options in their respective tsconfig.json files, it's important that a developer can specify the directory containing the tsconfig.json that the code should be compiled using.